### PR TITLE
Update to indicate that yum is only on redhat linux derivations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ have docs corresponding to your checked out version.
 We use Markdown to write and Jekyll to translate the documentation to static HTML. To install 
 Jekyll, you need to install the software as follows:
 
-    sudo yum install ruby ruby-devel nodejs python-pip
-    sudo gem install jekyll
-    sudo gem install kramdown
-    sudo pip Pygments
+For redhat linux systems:
+    `sudo yum install ruby ruby-devel nodejs python-pip`
+
+    `sudo gem install jekyll`
+    `sudo gem install kramdown`
+    `sudo pip Pygments`
 
 Kramdown is needed for Markdown processing and the Python based Pygments is used for syntax
 highlighting.


### PR DESCRIPTION
Under development - when doing `jekyll serve --watch`, all of the references pages return 404's. For example under 'Introduction -> Technical Highlights', I get a 404.

![screen shot 2015-10-29 at 1 26 35 pm](https://cloud.githubusercontent.com/assets/146453/10831100/b7a7b720-7e40-11e5-8b02-1636e904acd3.png)
